### PR TITLE
TG-2163: invalid code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 /.github/  @youwol/continuous-integration
-/.github/  @youwol/dev-front


### PR DESCRIPTION
This reverts commit c0e412acf848c51bbf264b6f583b8a79f12cafb4.

TG-2163
